### PR TITLE
Handle rate limits when building container

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -16,6 +16,7 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+      artifact-metadata: write
     
     strategy:
       matrix:
@@ -25,7 +26,7 @@ jobs:
   
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -51,13 +52,15 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            github_pat=${{ secrets.GITHUB_TOKEN }}
       
       # This step generates an artifact attestation for the image, which is an
       # unforgeable statement about where and how it was built. It increases supply chain
       # security for people who consume the image. For more information, 
       #see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v3
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ From GitHub:
 
  - python 3.12
  - R 4.4
- - poetry 2.1
- - nox 2025.2.9
+ - poetry 2.2.1
+ - nox 2025.11.12
 
 ## Releases
 
@@ -55,13 +55,19 @@ git push --tags
 
 ### Manually
 
+You need to set the environment variable GITHUB_PAT before running the commands.
+
+```shell
+export GITHUB_PAT="ghp_yourPersonalAccessTokenHere"
+```
+
 #### GitHub Action image (base)
 
 From the root of the repo:
 
 ```shell
 cd base
-docker build -t ghcr.io/statisticsnorway/docker-rpython-base:1.0 .
+docker build --secret id=github_pat,env=GITHUB_PAT -t ghcr.io/statisticsnorway/docker-rpython-base:1.0 .
 docker push ghcr.io/statisticsnorway/docker-rpython-base:1.0
 ```
 
@@ -71,7 +77,7 @@ From the root of the repo:
 
 ```shell
 cd dev
-docker build -t ghcr.io/statisticsnorway/docker-rpython-dev:1.0 .
+docker build --secret id=github_pat,env=GITHUB_PAT -t ghcr.io/statisticsnorway/docker-rpython-dev:1.0 .
 docker push ghcr.io/statisticsnorway/docker-rpython-dev:1.0
 ```
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,6 @@
-FROM rocker/r2u:24.04
+#syntax=docker/dockerfile:1
+
+FROM docker.io/rocker/r2u:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/statisticsnorway/docker-rpython
 LABEL org.opencontainers.image.description="Container for running both python and R, based on r2u."
@@ -24,10 +26,15 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN R -e "remotes::install_github(c(\
-   'statisticsnorway/ssb-metodebiblioteket', \
-   'statisticsnorway/ssb-fellesr' \
-   ))"   
+# Copy the R script that installs GitHub packages
+COPY install_github_r_packages.R /tmp/install_github_r_packages.R
+
+# Use a secret mount so the GITHUB_TOKEN is available only at build time
+RUN --mount=type=secret,id=github_pat \
+    bash -eux -c "\
+      export GITHUB_PAT=$(cat /run/secrets/github_pat) && \
+      Rscript /tmp/install_github_r_packages.R \
+    "
 
 ENV PATH=/root/.local/bin:$PATH
 

--- a/base/install_github_r_packages.R
+++ b/base/install_github_r_packages.R
@@ -1,0 +1,6 @@
+# Install R-packages from GitHub
+
+remotes::install_github(c(
+  "statisticsnorway/ssb-metodebiblioteket",
+  "statisticsnorway/ssb-fellesr"
+))


### PR DESCRIPTION
- Add use of GitHub PAT to avoid hitting rate limits when installing R-packages from GitHub.
- Update dependencies.